### PR TITLE
Added missing ')' to confirmation message

### DIFF
--- a/cogs/records.py
+++ b/cogs/records.py
@@ -216,7 +216,7 @@ class Records(commands.Cog):
             }
         )
         user_msg = await itx.edit_original_response(
-            content=f"{itx.user.mention}, is this correct? (Quality: {quality.name if not None else 'N/A'}{extra_content}",
+            content=f"{itx.user.mention}, is this correct? (Quality: {quality.name if not None else 'N/A'}) {extra_content}",
             embed=embed,
             view=view,
             attachments=[user_facing_screenshot],


### PR DESCRIPTION
I'm mostly figuring out how git works with this one but I noticed this typo when submitting a completion. I added the space to be safe but if its not meant to be there remove it